### PR TITLE
skip db query WHERE "id" IS NULL

### DIFF
--- a/plata/shop/views.py
+++ b/plata/shop/views.py
@@ -128,7 +128,10 @@ class Shop(object):
 
     def order_from_request(self, request, create=False):
         try:
-            return self.order_model.objects.get(pk=request.session.get('shop_order'))
+            order_pk = request.session.get('shop_order')
+            if order_pk is None:
+                raise ValueError("no order in session")
+            return self.order_model.objects.get(pk=order_pk)
         except (ValueError, self.order_model.DoesNotExist):
             if create:
                 contact = self.contact_from_user(request.user)


### PR DESCRIPTION
this happens when the request context "plata.order" is evaluated and there is no shop_order id in the session
