### PR TITLE
Custom font

### DIFF
--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -43,6 +43,17 @@ Settings
 ``PLATA_REPORTING_STATIONERY``:
   Stationery used by PDFDocument to render invoice and packing slip PDFs.
 
+``PLATA_PDF_FONT_NAME``:
+  Custom regular font name to be used by PDFDocument for rendering PDF invoices. Defaults to ``''`` (using default of ``reportlab``).
+
+``PLATA_PDF_FONT_PATH``
+  Custom regular font path to be used by PDFDocument for rendering PDF invoices. Defaults to ``''``.
+
+``PLATA_PDF_FONT_BOLD_NAME``
+  Custom bold font path to be used by PDFDocument for rendering PDF invoices. Defaults to ``''``.
+
+``PLATA_PDF_FONT_BOLD_PATH``
+  Custom bold font path to be used by PDFDocument for rendering PDF invoices. Defaults to ``''``.
 
 ``PLATA_STOCK_TRACKING``:
   Accurate transactional stock tracking. Needs the ``plata.product.stock``

--- a/plata/default_settings.py
+++ b/plata/default_settings.py
@@ -85,7 +85,7 @@ PLATA_SHOP_PRODUCT = getattr(settings, 'PLATA_SHOP_PRODUCT', 'product.Product')
 PLATA_ZIP_CODE_LABEL = getattr(settings, 'PLATA_ZIP_CODE_LABEL', _('ZIP code'))
 
 #: Custom font for PDF generation
-PLATA_CUSTOM_PDF_FONT_NAME = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_NAME', '')
-PLATA_CUSTOM_PDF_FONT_PATH = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_PATH', '')
-PLATA_CUSTOM_PDF_FONT_BOLD_NAME = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_BOLD_NAME', '')
-PLATA_CUSTOM_PDF_FONT_BOLD_PATH = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_BOLD_PATH', '')
+PLATA_PDF_FONT_NAME = getattr(settings, 'PLATA_PDF_FONT_NAME', '')
+PLATA_PDF_FONT_PATH = getattr(settings, 'PLATA_PDF_FONT_PATH', '')
+PLATA_PDF_FONT_BOLD_NAME = getattr(settings, 'PLATA_PDF_FONT_BOLD_NAME', '')
+PLATA_PDF_FONT_BOLD_PATH = getattr(settings, 'PLATA_PDF_FONT_BOLD_PATH', '')

--- a/plata/default_settings.py
+++ b/plata/default_settings.py
@@ -83,3 +83,9 @@ PLATA_SHOP_PRODUCT = getattr(settings, 'PLATA_SHOP_PRODUCT', 'product.Product')
 
 #: Since ZIP code is far from universal, and more an L10N than I18N issue:
 PLATA_ZIP_CODE_LABEL = getattr(settings, 'PLATA_ZIP_CODE_LABEL', _('ZIP code'))
+
+#: Custom font for PDF generation
+PLATA_CUSTOM_PDF_FONT_NAME = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_NAME', '')
+PLATA_CUSTOM_PDF_FONT_PATH = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_PATH', '')
+PLATA_CUSTOM_PDF_FONT_BOLD_NAME = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_BOLD_NAME', '')
+PLATA_CUSTOM_PDF_FONT_BOLD_PATH = getattr(settings, 'PLATA_CUSTOM_PDF_FONT_BOLD_PATH', '')

--- a/plata/reporting/pdfdocument.py
+++ b/plata/reporting/pdfdocument.py
@@ -8,25 +8,25 @@ import plata
 
 
 def init_regular_font(suffix=''):
-    name = "%s%s" % (plata.settings.PLATA_CUSTOM_PDF_FONT_NAME, suffix)
-    path = plata.settings.PLATA_CUSTOM_PDF_FONT_PATH or '%s.ttf' % name
+    name = "%s%s" % (plata.settings.PLATA_PDF_FONT_NAME, suffix)
+    path = plata.settings.PLATA_PDF_FONT_PATH or '%s.ttf' % name
     pdfmetrics.registerFont(TTFont(name, path))
 
 
 class PlataPDFDocument(PDFDocument):
 
     def __init__(self, *args, **kwargs):
-        if plata.settings.PLATA_CUSTOM_PDF_FONT_NAME:
+        if plata.settings.PLATA_PDF_FONT_NAME:
             init_regular_font()
             # add font name as parametr to parent PDFDocument class
-            kwargs['font_name'] = plata.settings.PLATA_CUSTOM_PDF_FONT_NAME
+            kwargs['font_name'] = plata.settings.PLATA_PDF_FONT_NAME
 
-        if plata.settings.PLATA_CUSTOM_PDF_FONT_BOLD_NAME:
+        if plata.settings.PLATA_PDF_FONT_BOLD_NAME:
             # init bold font variant
-            name = plata.settings.PLATA_CUSTOM_PDF_FONT_BOLD_NAME
-            path = plata.settings.PLATA_CUSTOM_PDF_FONT_BOLD_PATH or '%s.ttf' % name
+            name = plata.settings.PLATA_PDF_FONT_BOLD_NAME
+            path = plata.settings.PLATA_PDF_FONT_BOLD_PATH or '%s.ttf' % name
             pdfmetrics.registerFont(TTFont(name, path))
-        elif plata.settings.PLATA_CUSTOM_PDF_FONT_NAME:
+        elif plata.settings.PLATA_PDF_FONT_NAME:
             # init bold font variant from regular font, bold is always needed
             init_regular_font(suffix='-Bold')
 

--- a/plata/reporting/pdfdocument.py
+++ b/plata/reporting/pdfdocument.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import, unicode_literals
+
+from pdfdocument.document import PDFDocument
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+
+import plata
+
+
+def init_regular_font(suffix=''):
+    name = "%s%s" % (plata.settings.PLATA_CUSTOM_PDF_FONT_NAME, suffix)
+    path = plata.settings.PLATA_CUSTOM_PDF_FONT_PATH or '%s.ttf' % name
+    pdfmetrics.registerFont(TTFont(name, path))
+
+
+class PlataPDFDocument(PDFDocument):
+
+    def __init__(self, *args, **kwargs):
+        if plata.settings.PLATA_CUSTOM_PDF_FONT_NAME:
+            init_regular_font()
+            # add font name as parametr to parent PDFDocument class
+            kwargs['font_name'] = plata.settings.PLATA_CUSTOM_PDF_FONT_NAME
+
+        if plata.settings.PLATA_CUSTOM_PDF_FONT_BOLD_NAME:
+            # init bold font variant
+            name = plata.settings.PLATA_CUSTOM_PDF_FONT_BOLD_NAME
+            path = plata.settings.PLATA_CUSTOM_PDF_FONT_BOLD_PATH or '%s.ttf' % name
+            pdfmetrics.registerFont(TTFont(name, path))
+        elif plata.settings.PLATA_CUSTOM_PDF_FONT_NAME:
+            # init bold font variant from regular font, bold is always needed
+            init_regular_font(suffix='-Bold')
+
+        super(PlataPDFDocument, self).__init__(*args, **kwargs)
+

--- a/plata/reporting/views.py
+++ b/plata/reporting/views.py
@@ -8,6 +8,7 @@ from pdfdocument.utils import pdf_response
 import plata
 import plata.reporting.product
 import plata.reporting.order
+from plata.reporting.pdfdocument import PlataPDFDocument
 
 
 @staff_member_required
@@ -25,7 +26,7 @@ def invoice_pdf(request, order_id):
     """
     order = get_object_or_404(plata.shop_instance().order_model, pk=order_id)
 
-    pdf, response = pdf_response('invoice-%09d' % order.id)
+    pdf, response = pdf_response('invoice-%09d' % order.id, pdfdocument=PlataPDFDocument)
     plata.reporting.order.invoice_pdf(pdf, order)
     return response
 
@@ -37,6 +38,6 @@ def packing_slip_pdf(request, order_id):
     """
     order = get_object_or_404(plata.shop_instance().order_model, pk=order_id)
 
-    pdf, response = pdf_response('packing-slip-%09d' % order.id)
+    pdf, response = pdf_response('packing-slip-%09d' % order.id, pdfdocument=PlataPDFDocument)
     plata.reporting.order.packing_slip_pdf(pdf, order)
     return response

--- a/plata/shop/notifications.py
+++ b/plata/shop/notifications.py
@@ -78,20 +78,20 @@ from django.utils.translation import activate
 
 class BaseHandler(object):
     def invoice_pdf(self, order):
-        from pdfdocument.document import PDFDocument
+        from plata.reporting.pdfdocument import PlataPDFDocument
         from plata.reporting.order import invoice_pdf
 
         with contextlib.closing(BytesIO()) as content:
-            pdf = PDFDocument(content)
+            pdf = PlataPDFDocument(content)
             invoice_pdf(pdf, order)
             return content.getvalue()
 
     def packing_slip_pdf(self, order):
-        from pdfdocument.document import PDFDocument
+        from plata.reporting.pdfdocument import PlataPDFDocument
         from plata.reporting.order import packing_slip_pdf
 
         with contextlib.closing(BytesIO()) as content:
-            pdf = PDFDocument(content)
+            pdf = PlataPDFDocument(content)
             packing_slip_pdf(pdf, order)
             return content.getvalue()
 

--- a/tests/testapp/tests/test_models.py
+++ b/tests/testapp/tests/test_models.py
@@ -11,12 +11,12 @@ from django.core.serializers import serialize
 from django.db.models import Q
 from django.utils import six, timezone
 
-from pdfdocument.document import PDFDocument
 
 import plata
 from plata.discount.models import Discount, DiscountBase
 from plata.product.stock.models import Period, StockTransaction
 import plata.reporting.order
+from plata.reporting.pdfdocument import PlataPDFDocument
 from plata.shop.models import Order, OrderStatus, OrderPayment
 
 from .base import PlataTest
@@ -899,7 +899,7 @@ class ModelTest(PlataTest):
         # This should not crash; generating a PDF exercises the methods
         # and properties of the order
         plata.reporting.order.invoice_pdf(
-            PDFDocument(BytesIO()),
+            PlataPDFDocument(BytesIO()),
             Order.objects.create())
 
     def test_25_discount_validation(self):


### PR DESCRIPTION
I had a problem with rendeging some czech characters in PDF invoices. I figured that it's caused by font that doesn't support some czech letters (default of reportlab - Helvetica). 
I think that best solution would be to let package user choose which font should be used. So I added option for that. 
You can just add for example `PLATA_CUSTOM_PDF_FONT_NAME = 'DejaVuSans'`, no need to fill all new setting variables.
I also updated docs, but it may need some polishing.