### PR TITLE
updating item data before price calculation

### DIFF
--- a/plata/shop/models.py
+++ b/plata/shop/models.py
@@ -433,6 +433,10 @@ class Order(BillingShippingAddress):
             item.quantity = absolute
 
         if item.quantity > 0:
+            
+            if data is not None:
+                item.data = data
+
             try:
                 price = product.get_price(
                     currency=self.currency,
@@ -445,9 +449,6 @@ class Order(BillingShippingAddress):
                 raise ValidationError(
                     _('The price could not be determined.'),
                     code='unknown_price')
-
-            if data is not None:
-                item.data = data
 
             price.handle_order_item(item)
             product.handle_order_item(item)


### PR DESCRIPTION
In the `modify_item` method of the default Order model, data stored in `data` JSONField are updated before calling `get_price` on the related product. This way the updated data for the product can be used for lookup, selection or creation of a Price instance.
closes #78 